### PR TITLE
Custom text button and hide/not hide keyboard on submit

### DIFF
--- a/UIInputToolbarSample/Classes/UIInputToolbar/UIInputToolbar.h
+++ b/UIInputToolbarSample/Classes/UIInputToolbar/UIInputToolbar.h
@@ -34,9 +34,11 @@
 @interface UIInputToolbar : UIToolbar <UIExpandingTextViewDelegate>
 
 - (void)drawRect:(CGRect)rect;
+- (void)setLabel:(NSString*)text;
 
 @property (nonatomic, strong) UIExpandingTextView *textView;
 @property (nonatomic, strong) UIBarButtonItem *inputButton;
 @property (nonatomic, weak) id<UIInputToolbarDelegate> inputDelegate;
+@property (nonatomic, assign) BOOL hideKeyboardOnSubmit;
 
 @end

--- a/UIInputToolbarSample/Classes/UIInputToolbar/UIInputToolbar.m
+++ b/UIInputToolbarSample/Classes/UIInputToolbar/UIInputToolbar.m
@@ -35,7 +35,9 @@
     }
 
     /* Remove the keyboard and clear the text */
-    [self.textView resignFirstResponder];
+    if(self.hideKeyboardOnSubmit){
+        [self.textView resignFirstResponder];
+    }
     [self.textView clearText];
 }
 
@@ -64,6 +66,7 @@
     self.inputButton.customView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin;
     /* Disable button initially */
     self.inputButton.enabled = NO;
+    self.hideKeyboardOnSubmit = YES;
 
     /* Create UIExpandingTextView input */
     self.textView = [[UIExpandingTextView alloc] initWithFrame:CGRectMake(7, 7, self.bounds.size.width - 84, 26)];
@@ -93,6 +96,10 @@
         [self setupToolbar:@"Send"];
     }
     return self;
+}
+
+- (void)setLabel:(NSString*)text{
+    [self setupToolbar:text];
 }
 
 - (void)drawRect:(CGRect)rect


### PR DESCRIPTION
I've added a new feature to change the text of the button (it was a fixed string - "Send"). You can now set it with this function:

```
[inputToolbar setLabel:@"Enviar"];
```

So you can localize it.

Another new feature is to disable (or enable) the automatic hiding of the keyboard after clicking the button. To do that, you can set to NO or YES the attribute hideKeyboardOnSubmit:

```
inputToolbar.hideKeyboardOnSubmit = NO;
```
